### PR TITLE
1.2.4

### DIFF
--- a/files/js/element.js
+++ b/files/js/element.js
@@ -27,7 +27,6 @@
             });
         }
     });
-    });
 
     return PricingTable;
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest": "1",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "elements": [
     {
       "name": "Price Chart",
       "path": "files",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "settings": {
         "config": {
           "autopop": false


### PR DESCRIPTION
1.2.4 Updates

element.js was broken (extra closing brace and paren.) Apparently this slipped through, and would cause some problems with published price charts.

@M-Porter @rchen1992 